### PR TITLE
space-making-action: Init option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,18 @@ jobs:
 
       - name: Run common checks after the build
         uses: ./.github/support/extra-info
+
+  input-space-making:
+    name: "inputs: space-making"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: nix-build
+        uses: ./
+        with:
+          space-making-action: "more-space-action"
+
+      - name: Run common checks after the build
+        uses: ./.github/support/extra-info

--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ Whether the repository will be checked-out automatically with the actions/checko
 Use `false` to bring your own checkout action alternative.
 
 
+### `space-making-action`
+
+*Default: `none`*
+
+Space making action to use.
+
+Supports the following:  `[ "none" "more-space-action" ]`.
+
+Not enabled by default as it adds some time to the action runtime, while not always being necessary.
+
+
 ### `installer-action`
 
 *Default: `lix-gha-installer-action`*

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,16 @@ inputs:
     required: false
     default: "true"
 
+  space-making-action:
+    description: |
+      Space making action to use.
+
+      Supports the following:  `[ "none" "more-space-action" ]`.
+
+      Not enabled by default as it adds some time to the action runtime, while not always being necessary.
+    required: false
+    default: "none"
+
   installer-action:
     description: |
       Installer action to use.
@@ -88,8 +98,32 @@ runs:
       if: ${{ inputs.checkout-repo == 'true' }}
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    - uses: samueldr/more-space-action@latest
+      if: ${{ inputs.space-making-action == 'more-space-action' }}
+      with:
+        enable-lvm-span: true
+        lvm-span-mountpoint: /nix
+
     - uses: samueldr/lix-gha-installer-action@8bb402f5d394241dece8c7dd9f5c9f459649a03a # v1
       if: ${{ inputs.installer-action == 'lix-gha-installer-action' }}
+
+    - name: Override nix-daemon build directory
+      if: ${{ inputs.space-making-action != 'none' }}
+      shell: bash
+      run: |
+        (
+        PS4=" $ "
+        set -eux -o pipefail
+        sudo mkdir -p /nix/tmp
+        sudo chmod ug=rwx,o=rwxt /nix/tmp
+        sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
+        sudo tee /etc/systemd/system/nix-daemon.service.d/override.conf >/dev/null <<EOF
+        [Service]
+        Environment=TMPDIR=/nix/tmp
+        EOF
+        sudo systemctl daemon-reload
+        sudo systemctl restart nix-daemon
+        )
 
     - uses: DeterminateSystems/magic-nix-cache-action@87b14cf437d03d37989d87f0fa5ce4f5dc1a330b # 8
       if: ${{ inputs.cache-action == 'DeterminateSystems/magic-nix-cache' }}


### PR DESCRIPTION
While this action caters to *simple use-cases*, big builds ***absolutely positively can*** be simple. The *interface* to the Nix expressions need to be simple.

Out of the box, there's only ~28GiB for building stuff... That's not that much, when you want to i.e. cross-compile an installer image, when the image itself can be a couple GiB, then the packages going into it, then the packages needed to build it, with cross-compilation overhead, and finally the sandbox directories. [As can be observed here](https://github.com/samueldr/cross-system/actions/runs/12896548355/job/35959810113).

```
Gathering final system statistics...
  Before:
      Filesystem      Size  Used Avail Use% Mounted on
      /dev/root        72G   44G   28G  62% /
      /dev/sdb1        74G  4.1G   66G   6% /mnt
  After:
      Filesystem                 Size  Used Avail Use% Mounted on
      /dev/root                   72G   71G  1.0G  99% /
      /dev/sdb1                   74G   70G  100M 100% /mnt
      /dev/mapper/lvm_span-main  131G   28K  131G   1% /nix
```