### PR TITLE
initial-random-delay: Init option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,3 +198,18 @@ jobs:
 
       - name: Run common checks after the build
         uses: ./.github/support/extra-info
+
+  input-random-delay:
+    name: "inputs: initial-random-delay"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: nix-build
+        uses: ./
+        with:
+          initial-random-delay-max: 120
+
+      - name: Run common checks after the build
+        uses: ./.github/support/extra-info

--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ Supports the following: `[ "DeterminateSystems/magic-nix-cache" "none" ]`.
 Use `none` to disable or bring your own.
 
 
+### `initial-random-delay-max`
+
+*Default: `0`*
+
+Setting this option to a numeric value other than zero enables waiting a random amount of time at the start of the action.
+
+This is a common repeated pattern used to work around a thundering herd of github actions trampling over the API rate limits when dealing with multiple parallel builds, which may be exacerbated by using a matrix strategy.
+
+
 <!-- ACTION.YML INPUTS END -->
 
 * * *

--- a/action.yml
+++ b/action.yml
@@ -91,9 +91,30 @@ inputs:
   #  required: false
   #  default: "none"
 
+  #
+  # Additional nice features
+  #
+
+  initial-random-delay-max:
+    description: |
+      Setting this option to a numeric value other than zero enables waiting a random amount of time at the start of the action.
+
+      This is a common repeated pattern used to work around a thundering herd of github actions trampling over the API rate limits when dealing with multiple parallel builds, which may be exacerbated by using a matrix strategy.
+    required: false
+    default: "0"
+
 runs:
   using: "composite"
   steps:
+    - name: 💤 Random delay
+      if: ${{ inputs.initial-random-delay-max != '0' }}
+      shell: bash
+      run: |
+        delay=$(( RANDOM % ( ${{ inputs.initial-random-delay-max }} ) ))
+        printf "Waiting for %d seconds...\n" "$delay"
+        while (( delay-- && delay > 0 )); do printf "."; sleep 1; done
+        printf "\n... done!\n"
+
     - name: Checkout repository
       if: ${{ inputs.checkout-repo == 'true' }}
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This might look like an oddball option. And it kinda is.

This is mainly used to (hopefully) spread the load of a thundering herd of GitHub Actions making API calls all at once, getting rate limited or entirely denied access.

This is something that can be observed with the cache API, especially when combined with a build matrix.

Obviously this is not enabled by default, as it's kinda bogus to wait for no good reason.

As this option aims to reduce (my) common repeated patterns around Nix builds in GitHub Actions, it makes sense to place it here. Especially since it's not onerous step to maintain nor to run, and it can make a big difference in usability.